### PR TITLE
Fixed missed escape of round parentheses within SVG images

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = function(options) {
       data = file.contents.toString('utf8');
       data = data.replace(/'/g, '"');
       data = data.replace(/\s+/g, " ");
-      data = data.replace(/[{}\|\\\^~\[\]`"<>#%]/g, function(match) {
+      data = data.replace(/[\(\){}\|\\\^~\[\]`"<>#%]/g, function(match) {
         return '%'+match[0].charCodeAt(0).toString(16).toUpperCase();
       });
 


### PR DESCRIPTION
This pull request fixes currently (as of v1.0.3) missed escape for round parentheses witin SVG images. Since image by itself is embedded into CSS as `url(data:svg-image)` - lack of escaping for round parentheses results into preemptive close of `url()` expression and leads to broken image and errors from CSS post-processors (such as PostCSS) because of broken CSS.

Round parentheses in SVG may show up from, for example, url references or transformations or from text nodes.