### PR TITLE
Fixed lack of quotes for inline SVG images that may lead to broken CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = function(options) {
       data = file.contents.toString('utf8');
       data = data.replace(/'/g, '"');
       data = data.replace(/\s+/g, " ");
-      data = data.replace(/[\(\){}\|\\\^~\[\]`"<>#%]/g, function(match) {
+      data = data.replace(/[\(\){}\|\\\^~\[\]`"\'<>#%]/g, function(match) {
         return '%'+match[0].charCodeAt(0).toString(16).toUpperCase();
       });
 
@@ -135,7 +135,7 @@ module.exports = function(options) {
     // Replace /, \, . and @ with -
     imageInfo.fullname  = imageInfo.path.replace(/[\/\\\.@]/g, '-');
     imageInfo.hash      = md5(file.contents);
-    imageInfo.data      = 'url(data:' + mimetype + ';' + encoding + ',' + data + ')';
+    imageInfo.data      = 'url(\'data:' + mimetype + ';' + encoding + ',' + data + '\')';
 
     images.push(imageInfo);
   };


### PR DESCRIPTION
Currently `data:` urls for images are stored within `url()` without being quoted. In a case of base64-encoded images it is ok, but plain SVG images may break CSS syntax so it is safer to keep them as explicit quoted string. It also let CSS parsers to skip parsing of SVG information but rather treat it as plain string. For example PostCSS sometimes breaks on attempts to parse inlined SVG and while it may be a problem of PostCSS itself - it is simple and safe to just quote inlined SVG images.