### PR TITLE
Fix Duplicate images Data

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,8 @@ function endStream() {
         path: options.targetFile,
     }));
     this.emit('end');
+
+    images.length = 0
 }
 
 module.exports = (opts = {}) => {


### PR DESCRIPTION
gulp watch output Duplicate images Data

$compass-imagehelper-imagesmap: (
  'logo.svg': (
    width: '289',
    height: '122',
    hash: '841dfd72ef3a561a11fbc920f23f3031'
  ),
 'logo.svg': (
    width: '289',
    height: '122',
    hash: '841dfd72ef3a561a11fbc920f23f3031'
  ),
 'logo.svg': (
    width: '289',
    height: '122',
    hash: '841dfd72ef3a561a11fbc920f23f3031'
  ),
);