### PR TITLE
Fixed problem with duplicated image entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const appRoot = require('app-root-path').path;
 
 const svgo = new SVGO();
 
-const images = [];
+let images = [];
 let options = {
     template: path.join(__dirname, 'sass-image-template.mustache'),
     targetFile: '_sass-image.scss',
@@ -137,6 +137,7 @@ function endStream() {
 }
 
 module.exports = (opts = {}) => {
+    images = [];
     options = Object.assign(options, opts);
 
     if (options.includeData !== false) {


### PR DESCRIPTION
This patch fixes issue #7 that causes duplicated image entries to be generated by plugin in a case of repetitive calls of plugin e.g. in a case of use it within `gulp watch`